### PR TITLE
特定イベントAPIを追加

### DIFF
--- a/_examples/events.go
+++ b/_examples/events.go
@@ -7,7 +7,7 @@ import (
 	"github.com/g0tiu5a/ctftime"
 )
 
-func main() {
+func GetEvents() {
 	url, err := ctftime.GetUrl("events", nil)
 	if err != nil {
 		log.Fatal(err)
@@ -28,4 +28,35 @@ func main() {
 		fmt.Printf("[event%d]\n", idx)
 		fmt.Printf("%#v\n", event)
 	}
+}
+
+func GetSpecifiedEvent() {
+	ctx := ctftime.APIContext{
+		"event_id": 1,
+	}
+
+	url, err := ctftime.GetUrl("events", ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("[==>] Requesting %s ...\n", url)
+
+	obj, err := ctftime.GetAPIData("events", ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	event, ok := obj.(ctftime.Event)
+	if !ok {
+		log.Fatal("event")
+	}
+
+	fmt.Printf("%#v\n", event)
+}
+
+func main() {
+	fmt.Println("[*] Trying All events api ...")
+	GetEvents()
+	fmt.Println("[*] Trying Specified event api ...")
+	GetSpecifiedEvent()
 }

--- a/events.go
+++ b/events.go
@@ -22,19 +22,34 @@ func init() {
 }
 
 func (client *eventsAPIClient) GetUrl() (string, error) {
-	now := time.Now().Unix()
+	if event_id, ok := client.Ctx["event_id"]; ok {
+		// 特定のイベントを取得するAPI
+		// https://ctftime.org/api/v1/events/{event_id}/
+		req, err := http.NewRequest(
+			"GET",
+			fmt.Sprintf("%s/events/%d/", API_ENDPOINT, event_id.(int)),
+			nil,
+		)
+		if err != nil {
+			return "", err
+		}
+		return req.URL.String(), nil
+	} else {
+		// 特定期間の複数のイベントを取得するAPI
+		// https://ctftime.org/api/v1/events/?limit={number}&start={timestamp}&finish={timestamp}
+		now := time.Now().Unix()
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/events/", API_ENDPOINT), nil)
-	if err != nil {
-		return "", err
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s/events/", API_ENDPOINT), nil)
+		if err != nil {
+			return "", err
+		}
+
+		q := req.URL.Query()
+		q.Add("limit", fmt.Sprintf("%d", LIMIT))
+		q.Add("start", strconv.FormatInt(now, 10))
+		req.URL.RawQuery = q.Encode()
+		return req.URL.String(), nil
 	}
-
-	q := req.URL.Query()
-	q.Add("limit", fmt.Sprintf("%d", LIMIT))
-	q.Add("start", strconv.FormatInt(now, 10))
-	req.URL.RawQuery = q.Encode()
-
-	return req.URL.String(), nil
 }
 
 func (client *eventsAPIClient) GetAPIData() (interface{}, error) {
@@ -49,7 +64,13 @@ func (client *eventsAPIClient) GetAPIData() (interface{}, error) {
 	}
 	defer resp.Body.Close()
 
-	var events Events
-	httpResponseToStruct(resp, &events)
-	return events, nil
+	if _, ok := client.Ctx["event_id"]; ok {
+		var event Event
+		httpResponseToStruct(resp, &event)
+		return event, nil
+	} else {
+		var events Events
+		httpResponseToStruct(resp, &events)
+		return events, nil
+	}
 }

--- a/events_test.go
+++ b/events_test.go
@@ -47,3 +47,35 @@ func TestGetEventsData(t *testing.T) {
 		}
 	}
 }
+
+func TestGetEventData(t *testing.T) {
+	ctx := APIContext{
+		"event_id": 1,
+	}
+
+	result, err := GetAPIData("events", ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	body, err := json.Marshal(result)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	dummy_resp := &http.Response{
+		StatusCode: 200,
+		ProtoMajor: 1,
+		ProtoMinor: 0,
+		Body:       ioutil.NopCloser(bytes.NewReader(body)),
+	}
+
+	var dummy_event Event
+	httpResponseToStruct(dummy_resp, &dummy_event)
+
+	valid := reflect.TypeOf(Event{})
+	actual := reflect.TypeOf(dummy_event)
+	if actual != valid {
+		t.Errorf("Invalid event type of %v! (should be %v).", actual, valid)
+	}
+}


### PR DESCRIPTION
特定のイベント(event_idを指定)取得するAPIクライアント実装をしました。

テストを書いて、events.goにクライアント実装を組み込み、テストが一通り通ったあとに_examplesのevents.goに追加分を書き足した感じです。

確認よろしくお願いいたします。